### PR TITLE
v1.8.0.0

### DIFF
--- a/Athena/Athena.csproj
+++ b/Athena/Athena.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <ApplicationIcon>Athena.ico</ApplicationIcon>
-	<Version>1.7.8.8</Version>
+	<Version>1.8.0.0</Version>
     <IncludeNativeLibrariesForSelfExtract>true</IncludeNativeLibrariesForSelfExtract>
   </PropertyGroup>
 

--- a/Athena/Globals.cs
+++ b/Athena/Globals.cs
@@ -2,7 +2,7 @@
 
 public static class Globals
 {
-    public const string VERSION = "1.7.8.8";
+    public const string VERSION = "1.8.0.0";
     public const string APPID = "1142239120471634042";
     public const string DISCORD = "https://discord.gg/nJBj9NjUS4";
     public const string DOWNLOAD = "https://github.com/djlorenzouasset/Athena/releases/latest";

--- a/Athena/Managers/Dataminer.cs
+++ b/Athena/Managers/Dataminer.cs
@@ -55,7 +55,12 @@ public class Dataminer
         "DefaultContrail", "DefaultGlider", "DefaultPickaxe", // default items (issue #33)
 
         "BoltonPickaxe", "Dev_Test_Pickaxe", "HalloweenScythe", // pickaxes without prefix (issue #61)
-        "HappyPickaxe", "SickleBatPickaxe", "SkiIcePickaxe", "SpikyPickaxe"
+        "HappyPickaxe", "SickleBatPickaxe", "SkiIcePickaxe", "SpikyPickaxe",
+
+        "ChillyFabric", "FounderGlider", "FounderUmbrella", "Gadget_AlienSignalDetector", // more unprefixed cosmetics (issue #69)
+        "Gadget_DetectorGadget", "Gadget_DetectorGadget_Ch4S2", "Gadget_HighTechBackpack",
+        "Gadget_RealityBloom", "Gadget_SpiritVessel", "PreSeasonGlider", "PreSeasonGlider_Elite",
+        "Solo_Umbrella", "Solo_Umbrella_MarkII", "Squad_Umbrella"
     ];
     private readonly string[] _classes = [
         // BR
@@ -438,7 +443,7 @@ public class Dataminer
 
                     var variants = Helper.GetAllVariants(export);
                     profile.AddCosmetic(entry.NameWithoutExtension, variants);
-                    Log.Information("Added \"{name}\" with {totVariants} channels variants.", entry.NameWithoutExtension, variants.Count);
+                    Log.Information("Added \"{name}\" ({type}) with {totVariants} channels variants.", entry.NameWithoutExtension, export.ExportType, variants.Count);
                     added++;
                 }
                 catch (Exception e)

--- a/Athena/Managers/Dataminer.cs
+++ b/Athena/Managers/Dataminer.cs
@@ -47,7 +47,7 @@ public class Dataminer
         "MusicPack", "Umbrella",
         "LSID", "LoadingScreen",
         "Contrail", "Trails",
-        "Petcarrier", "Spid",
+        "PetCarrier", "Spid",
         "Toy", "Emoji", "Emoticon", "Spray",
         "Sparks_", "SparksAura", "SID",
         "ID", "Wheel", "CarBody", "CarSkin", "Body" /* issue #54 */,
@@ -321,6 +321,13 @@ public class Dataminer
         }
         else if (action == Actions.AddArchive)
         {
+            if (APIEndpoints.FNCentral.AesKey.DynamicKeys.Count == 0)
+            {
+                Log.Error("There are no available paks to select.");
+                await ReturnToMenu(true);
+                return;
+            }
+
             var selected = SelectArchive();
 
             _ioStoreNames.Add(selected.Name);

--- a/Athena/Managers/Dataminer.cs
+++ b/Athena/Managers/Dataminer.cs
@@ -60,7 +60,7 @@ public class Dataminer
         "ChillyFabric", "FounderGlider", "FounderUmbrella", "Gadget_AlienSignalDetector", // more unprefixed cosmetics (issue #69)
         "Gadget_DetectorGadget", "Gadget_DetectorGadget_Ch4S2", "Gadget_HighTechBackpack",
         "Gadget_RealityBloom", "Gadget_SpiritVessel", "PreSeasonGlider", "PreSeasonGlider_Elite",
-        "Solo_Umbrella", "Solo_Umbrella_MarkII", "Squad_Umbrella"
+        "Solo_Umbrella", "Solo_Umbrella_MarkII", "Squad_Umbrella", "Duo_Umbrella"
     ];
     private readonly string[] _classes = [
         // BR

--- a/Athena/Managers/Dataminer.cs
+++ b/Athena/Managers/Dataminer.cs
@@ -228,7 +228,7 @@ public class Dataminer
             new SelectionPrompt<string>()
                 .Title("What do you want generate?")
                 .AddChoices(_athenaOptions)
-            );
+        );
 
         Model model = Model.ProfileAthena; // default
         switch (selected)
@@ -457,6 +457,8 @@ public class Dataminer
                 {
 #if DEBUG
                     Log.Error("Skipped entry {name}: {err}.", entry.Name, e.Message);
+#else
+                    Log.ForContext("NoConsole", true).Error("Skipped entry {name}: {err}.", entry.Name, e.Message);
 #endif
                 }
             }

--- a/Athena/Services/Helper.cs
+++ b/Athena/Services/Helper.cs
@@ -284,7 +284,7 @@ public static class Helper
                     if (tag is null) continue;
 
                     if (tag.Contains("Property.Color") || tag.Contains("Vehicle.Painted") || tag.Contains("Vehicle.Tier") || 
-                        tag.Contains("Outfit.") || tag.Contains("Theme."))
+                        tag.Contains("Property.Outfit") || tag.Contains("Property.Theme"))
                     {
                         ownedParts.Add(tag.Split("Property.").Last());
                     }
@@ -300,8 +300,9 @@ public static class Helper
             var variantChannelTag = style.GetOrDefault<FStructFallback>("VariantChannelTag");
             if (variantChannelTag is null && optionsName == "Variants")
             {
-                // when a cosmetic uses FortCosmeticLoadoutTagDrivenVariant, the first variant using that type doesn't have
-                // the VariantChannelTag property, so we set it to TagDriven (idk why, but I saw this from a real game profile)
+                // when a cosmetic uses FortCosmeticLoadoutTagDrivenVariant, the first variant of that type
+                // doesnt have the VariantChannelTag property. In this case, we set it to "TagDriven"
+                // (not sure why, but I observed this in a real game profile).
                 channel = "TagDriven";
             }
             else if (variantChannelTag is null)

--- a/Athena/Services/Helper.cs
+++ b/Athena/Services/Helper.cs
@@ -11,13 +11,34 @@ namespace Athena.Services;
 
 public static class Helper
 {
-    private static readonly List<string> _notPrefixedPickaxes = [ // pickaxes without prefix (issue #61)
-        "BoltonPickaxe", "Dev_Test_Pickaxe", "HalloweenScythe",
-        "HappyPickaxe", "SickleBatPickaxe", "SkiIcePickaxe", "SpikyPickaxe"
-    ];
-    private static readonly Dictionary<string, string> _defaultCosmetics = new() { // default items (issue #33)
+    private static readonly Dictionary<string, string> _notPrefixedCosmetics = new() { // cosmetics without prefix (issue #61 & #69)
+        { "BoltonPickaxe", "AthenaPickaxe" },
+        { "Dev_Test_Pickaxe", "AthenaPickaxe" },
+        { "HalloweenScythe", "AthenaPickaxe" },
+        { "HappyPickaxe", "AthenaPickaxe" },
+        { "SickleBatPickaxe", "AthenaPickaxe" },
+        { "SkiIcePickaxe", "AthenaPickaxe" },
+        { "SpikyPickaxe", "AthenaPickaxe" },
+        { "ChillyFabric", "AthenaItemWrap" },
+        { "Duo_Umbrella", "AthenaGlider" },
+        { "FounderGlider", "AthenaGlider" },
+        { "FounderUmbrella", "AthenaGlider" },
+        { "Gadget_AlienSignalDetector", "AthenaBackpack" },
+        { "Gadget_DetectorGadget", "AthenaBackpack" },
+        { "Gadget_DetectorGadget_Ch4S2", "AthenaBackpack" },
+        { "Gadget_HighTechBackpack", "AthenaBackpack" },
+        { "Gadget_RealityBloom", "AthenaBackpack" },
+        { "Gadget_SpiritVessel", "AthenaBackpack" },
+        { "PreSeasonGlider", "AthenaGlider" },
+        { "PreSeasonGlider_Elite", "AthenaGlider" },
+        { "Solo_Umbrella", "AthenaGlider" },
+        { "Solo_Umbrella_MarkII", "AthenaGlider" },
+        { "Squad_Umbrella", "AthenaGlider" }
+    };
+    private static readonly Dictionary<string, string> _defaultCosmetics = new() { // default items (issue #33 & #69)
         { "DefaultPickaxe", "AthenaPickaxe" },
-        { "DefaultGlider", "AthenaGlider" }
+        { "DefaultGlider", "AthenaGlider" },
+        { "DefaultContrail", "AthenaSkyDiveContrail" }
     };
 
     private static readonly string DEFAULT_VARIANT_NAME = "UnknownVariantName"; // default name for variants name
@@ -129,13 +150,10 @@ public static class Helper
         };
 
         string prefix;
-        if (_defaultCosmetics.TryGetValue(id, out string? value))
+        if (_defaultCosmetics.TryGetValue(id, out string? value) ||
+            _notPrefixedCosmetics.TryGetValue(id, out value))
         {
             return value;
-        }
-        else if (_notPrefixedPickaxes.Contains(id))
-        {
-            return "AthenaPickaxe";
         }
         else if (id.StartsWith("Sparks_"))
         {


### PR DESCRIPTION
### Issue #69 (Thanks to @HyperKiko)
- Added support for more unprefixed cosmetics.
- Added support for `FortCosmeticCIDRedirectorVariant` and `FortCosmeticLoadoutTagDrivenVariant` variants.

### General Fixes
- Fixed an issue where an empty menu was shown when no paks were available and the user selected "Pak Cosmetics."
- Added logging of cosmetic-related errors to the app's log file.